### PR TITLE
Rollup 2 peer dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "rollup-pluginutils": "^2.8.2"
   },
   "peerDependencies": {
-    "rollup": "^1.27.9"
+    "rollup": "^1.27.9||^2.0.0"
   }
 }


### PR DESCRIPTION
Hey there, minor update to avoid peer dependency warning with Rollup 2.