### PR TITLE
fix: export from default

### DIFF
--- a/lib/import-to-globals.js
+++ b/lib/import-to-globals.js
@@ -65,6 +65,7 @@ function analyzeExportNamed(node, code, getName, tempNames) {
     const legalName = /^[\w$]+$/.test(globalName) ? null : `_global_${makeLegalIdentifier(globalName)}`;
     if (!legalName) {
       writeSpecLocal(code, spec, globalName);
+      code.appendRight(node.start, `const ${globalName} = globalThis.${globalName};\n`);
     } else {
       if (!tempNames.has(legalName)) {
         code.appendRight(node.start, `const ${legalName} = ${globalName};\n`);

--- a/test/test.js
+++ b/test/test.js
@@ -298,8 +298,7 @@ describe("main", () => {
     })
   );
 
-  // https://github.com/acornjs/acorn/issues/806
-  xit("export from default", () =>
+  it("export from default", () =>
     withDir(`
       - entry.js: |
           export {default as baz} from "bak";
@@ -310,7 +309,10 @@ describe("main", () => {
         boo: "BOO",
       });
       assert.equal(code.trim(), endent`
-        export { BAK as baz, BOO };
+        const BAK = globalThis.BAK;
+        const BOO = globalThis.BOO;
+
+        export { BOO, BAK as baz };
       `);
     })
   );


### PR DESCRIPTION
### What

Fix https://github.com/eight04/rollup-plugin-external-globals/issues/19

### How

add a variable declaration syntax before export

### Resource

`globalThis` spec: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis