### PR TITLE
fix: use cjs export assignment in type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,4 +22,6 @@ type ExternalGlobalsOptions = {
   dynamicWrapper?: ((variableName: VariableName) => string)
 }
 
-export default function externalGlobals(globals: ModuleNameMap, options?: ExternalGlobalsOptions): Plugin
+declare function externalGlobals(globals: ModuleNameMap, options?: ExternalGlobalsOptions): Plugin
+
+export = externalGlobals


### PR DESCRIPTION
As explained here:

https://arethetypeswrong.github.io/?p=rollup-plugin-external-globals%400.9.0

The types are currently incorrect and will fail to resolve properly in `nodenext` resolution.

This is because the exported function is actually an export-assignment, not a default export.

This change updates the types to match this.