### PR TITLE
fix: `local` and `exported` will never be the same object (rollup/rollup@3ba1511)

### DIFF
--- a/lib/import-to-globals.js
+++ b/lib/import-to-globals.js
@@ -44,7 +44,7 @@ function writeSpecLocal(code, root, spec, name, tempNames) {
   if (spec.local.name === localName) {
     return;
   }
-  if (spec.local === spec.exported) {
+  if (spec.local.start === spec.exported.start && spec.local.end === spec.exported.end) {
     code.appendRight(spec.local.start, `${localName} as `);
   } else {
     code.overwrite(spec.local.start, spec.local.end, localName);


### PR DESCRIPTION
As title says, this "breaking" update of upstream make us to change the code of this package in order to keep correctness.

See https://github.com/rollup/rollup/commit/3ba1511d1cd0925e3233ad30024c40645d5846f3#diff-9c5406bcdbe04fd5465cd46ceb57b50f991345832a90c526973bfa0b81d54a0aL369 for specific details.

<img width="1305" alt="1" src="https://github.com/eight04/rollup-plugin-external-globals/assets/31309196/a60d1baf-09c6-40de-8a08-d852c594647b">
