### PR TITLE
chore: Export types and allow named imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,32 @@
-import type {Plugin} from 'rollup'
+import type { Plugin } from "rollup";
 
-type VariableName = string
+export type VariableName = string;
 /**
  * globals is a moduleId/variableName map
  * or provide a function that takes the moduleId and returns the variableName
  */
-type ModuleNameMap = Record<string, string> | ((id: string) => VariableName)
+export type ModuleNameMap =
+  | Record<string, string>
+  | ((id: string) => VariableName);
 
-type ExternalGlobalsOptions = {
+export type ExternalGlobalsOptions = {
   /**
    * [include] is an array of glob patterns. If defined, only matched files would be transformed.
    */
-  include?: Array<string>
+  include?: Array<string>;
   /**
    * [exclude] is an array of glob patterns. Matched files would not be transformed.
    */
-  exclude?: Array<string>
+  exclude?: Array<string>;
   /**
    * [dynamicWrapper] is used to specify dynamic imports. It accepts a variable name and returns an expression
    */
-  dynamicWrapper?: ((variableName: VariableName) => string)
-}
+  dynamicWrapper?: (variableName: VariableName) => string;
+};
 
-declare function externalGlobals(globals: ModuleNameMap, options?: ExternalGlobalsOptions): Plugin
+export declare function externalGlobals(
+  globals: ModuleNameMap,
+  options?: ExternalGlobalsOptions
+): Plugin;
 
-export = externalGlobals
+export = externalGlobals;

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "globals"
   ],
   "main": "index.js",
-  "types": "index.d.ts",
+  "typings": "index.d.ts",
   "exports": {
-    "types": "./index.d.ts",
-    "import": "./index.js"
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
   },
   "files": [
     "lib",


### PR DESCRIPTION
Wondering if this is a welcomed contribution? when working with typescript it might be helpful to have the types out of the box. They are already present, just not exported. 

Let me know if there's anything I have to change :)