### PR TITLE
feat: use constBindings options to gen const or var code

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,10 +25,18 @@ function createPlugin(globals, {include, exclude, dynamicWrapper = defaultDynami
     throw new TypeError(`Unexpected type of 'dynamicWrapper', got '${dynamicWrapperType}'`);
   }
   const filter = createFilter(include, exclude);
+
+  let constBindings;
+
   return {
     name: "rollup-plugin-external-globals",
+    renderStart,
     transform
   };
+
+  function renderStart(outputOptions) {
+    constBindings = outputOptions.generatedCode.constBindings;
+  }
 
   async function transform(code, id) {
     if ((id[0] !== "\0" && !filter(id)) || (isGlobalsObj && Object.keys(globals).every(id => !code.includes(id)))) {
@@ -40,7 +48,8 @@ function createPlugin(globals, {include, exclude, dynamicWrapper = defaultDynami
       ast,
       code,
       getName,
-      getDynamicWrapper: dynamicWrapper
+      getDynamicWrapper: dynamicWrapper,
+      constBindings
     });
     return isTouched ? {
       code: code.toString(),

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function createPlugin(globals, {include, exclude, dynamicWrapper = defaultDynami
   }
   const filter = createFilter(include, exclude);
 
-  let constBindings;
+  let constBindings = false;
 
   return {
     name: "rollup-plugin-external-globals",
@@ -34,8 +34,12 @@ function createPlugin(globals, {include, exclude, dynamicWrapper = defaultDynami
     transform
   };
 
+  // https://github.com/rollup/rollup/blob/master/CHANGELOG.md#300
+  // since rollup@3.0.0 support outputOptions.generatedCode.constBindings
   function renderStart(outputOptions) {
-    constBindings = outputOptions.generatedCode.constBindings;
+    if (outputOptions.generatedCode) {
+      constBindings = outputOptions.generatedCode.constBindings;
+    }
   }
 
   async function transform(code, id) {

--- a/lib/import-to-globals.js
+++ b/lib/import-to-globals.js
@@ -38,7 +38,7 @@ function writeSpecLocal(code, root, spec, name, tempNames, constBindings) {
   // https://github.com/eight04/rollup-plugin-external-globals/issues/19
   const localName = `_global_${makeLegalIdentifier(name)}`;
   if (!tempNames.has(localName)) {
-    const cnst = constBindings ? 'const' : 'var';
+    const cnst = constBindings ? "const" : "var";
     code.appendRight(root.start, `${cnst} ${localName} = ${name};\n`);
     tempNames.add(localName);
   }
@@ -79,7 +79,7 @@ function analyzeExportNamed(node, code, getName, tempNames, constBindings) {
   }
   for (const spec of node.specifiers) {
     const globalName = makeGlobalName(spec.local.name, name);
-    writeSpecLocal(code, node, spec, globalName, tempNames);
+    writeSpecLocal(code, node, spec, globalName, tempNames, constBindings);
   }
   if (node.specifiers.length) {
     code.overwrite(node.specifiers[node.specifiers.length - 1].end, node.source.end, "}");
@@ -114,7 +114,7 @@ async function importToGlobals({ast, code, getName, getDynamicWrapper, constBind
     if (node.type === "ImportDeclaration") {
       isTouched = analyzeImport(node, bindings, code, getName, globals) || isTouched;
     } else if (node.type === "ExportNamedDeclaration") {
-      isTouched = analyzeExportNamed(node, code, getName, tempNames) || isTouched;
+      isTouched = analyzeExportNamed(node, code, getName, tempNames, constBindings) || isTouched;
     }
   }
   

--- a/lib/import-to-globals.js
+++ b/lib/import-to-globals.js
@@ -32,13 +32,14 @@ function makeGlobalName(prop, name) {
   return `${name}.${prop}`;
 }
 
-function writeSpecLocal(code, root, spec, name, tempNames) {
+function writeSpecLocal(code, root, spec, name, tempNames, constBindings) {
   if (spec.isOverwritten) return;
   // we always need an extra assignment for named export statement
   // https://github.com/eight04/rollup-plugin-external-globals/issues/19
   const localName = `_global_${makeLegalIdentifier(name)}`;
   if (!tempNames.has(localName)) {
-    code.appendRight(root.start, `const ${localName} = ${name};\n`);
+    const cnst = constBindings ? 'const' : 'var';
+    code.appendRight(root.start, `${cnst} ${localName} = ${name};\n`);
     tempNames.add(localName);
   }
   if (spec.local.name === localName) {
@@ -68,7 +69,7 @@ function writeIdentifier(code, node, parent, name) {
   }
 }
 
-function analyzeExportNamed(node, code, getName, tempNames) {
+function analyzeExportNamed(node, code, getName, tempNames, constBindings) {
   if (node.declaration || !node.source || !node.source.value) {
     return false;
   }
@@ -101,7 +102,7 @@ function getDynamicImportSource(node) {
   }
 }
 
-async function importToGlobals({ast, code, getName, getDynamicWrapper}) {
+async function importToGlobals({ast, code, getName, getDynamicWrapper, constBindings}) {
   await prepare();
   let scope = attachScopes(ast, "scope");
   const bindings = new Map;

--- a/test/test.js
+++ b/test/test.js
@@ -273,8 +273,8 @@ describe("main", () => {
         mud: "MUD"
       });
       assert.equal(code.trim(), endent`
-        const _global_FOO_foo = FOO.foo;
-        const _global_MUD_mud = MUD.mud;
+        var _global_FOO_foo = FOO.foo;
+        var _global_MUD_mud = MUD.mud;
         
         export { _global_FOO_foo as bar, _global_MUD_mud as mud };
       `);
@@ -291,7 +291,7 @@ describe("main", () => {
         foo: "FOO"
       });
       assert.equal(code.trim(), endent`
-        const _global_FOO_foo = FOO.foo;
+        var _global_FOO_foo = FOO.foo;
         
         export { _global_FOO_foo as bar, _global_FOO_foo as baz };
       `);
@@ -310,8 +310,8 @@ describe("main", () => {
         boo: "BOO",
       });
       assert.equal(code.trim(), endent`
-        const _global_BAK = BAK;
-        const _global_BOO = BOO;
+        var _global_BAK = BAK;
+        var _global_BOO = BOO;
       
         export { _global_BOO as BOO, _global_BAK as baz };
       `);
@@ -348,7 +348,7 @@ describe("main", () => {
     `, async resolve => {
       const {output: {"entry.js": {code}}} = await bundle(resolve("entry.js"), {foo: "FOO"});
       assert.equal(code.trim(), endent`
-        const _global_FOO = FOO;
+        var _global_FOO = FOO;
       
         export { _global_FOO as foo };
       `);
@@ -365,7 +365,7 @@ describe("main", () => {
     `, async resolve => {
       const {output: {"entry.js": {code}}} = await bundle(resolve("entry.js"), {foo: "FOO"});
       assert.equal(code.trim(), endent`
-        const _global_FOO = FOO;
+        var _global_FOO = FOO;
       
         export { _global_FOO as bar, _global_FOO as foo };
       `);
@@ -382,7 +382,7 @@ describe("main", () => {
       const {output: {"entry.js": {code}}} = await bundle(resolve("entry.js"), {foo: "FOO"});
       assert.equal(code.trim(), endent`
         console.log(FOO);
-        const _global_FOO = FOO;
+        var _global_FOO = FOO;
       
         export { _global_FOO as foo };
       `);


### PR DESCRIPTION
Similar to Rollup, use [constBindings](https://cn.rollupjs.org/configuration-options/#output-generatedcode-constbindings) is to control generated code uses const or var (the default is var). 
Regarding the `constBindings `configuration option, the current default value is es5, so this PR has break change.