### PR TITLE
types: update include and exclude type

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ This module exports a single function.
 const plugin = createPlugin(
   globals: Object | Function,
   {
-    include?: Array,
-    exclude?: Array,
+    include?: ReadonlyArray<string | RegExp> | string | RegExp | null,
+    exclude?: ReadonlyArray<string | RegExp> | string | RegExp | null,
     dynamicWrapper?: Function,
     constBindings?: Boolean
   } = {}
@@ -106,9 +106,9 @@ const globals = (id) => {
 }
 ```
 
-`include` is an array of glob patterns. If defined, only matched files would be transformed.
+`include` is a valid `picomatch` glob pattern, or array of patterns. If defined, only matched files would be transformed.
 
-`exclude` is an array of glob patterns. Matched files would not be transformed.
+`exclude` is a valid `picomatch` glob pattern, or array of patterns. Matched files would not be transformed.
 
 `dynamicWrapper` is used to specify dynamic imports. Below is the default.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
-import type { Plugin } from "rollup";
+import type { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
 
 export type VariableName = string;
 /**
@@ -11,13 +12,13 @@ export type ModuleNameMap =
 
 export type ExternalGlobalsOptions = {
   /**
-   * [include] is an array of glob patterns. If defined, only matched files would be transformed.
+   * [include] is a valid `picomatch` glob pattern, or array of patterns. If defined, only matched files would be transformed.
    */
-  include?: Array<string>;
+  include?: FilterPattern;
   /**
-   * [exclude] is an array of glob patterns. Matched files would not be transformed.
+   * [exclude] is a valid `picomatch` glob pattern, or array of patterns. Matched files would not be transformed.
    */
-  exclude?: Array<string>;
+  exclude?: FilterPattern;
   /**
    * [dynamicWrapper] is used to specify dynamic imports. It accepts a variable name and returns an expression
    */


### PR DESCRIPTION
# Problem

The version of `@rollup/pluginutils` is `^5.1.0`

![image](https://github.com/user-attachments/assets/338570b6-5951-44b2-9bdc-9b918d510c8b)

But the type is not same to `@rollup/pluginutils`.

![image](https://github.com/user-attachments/assets/bc12ec63-cd2e-4e8a-9579-19a62264bf3d)



